### PR TITLE
Added Health probe utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,5 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+.venv/

--- a/app.py
+++ b/app.py
@@ -79,12 +79,12 @@ def openapi_json():
             },
             "/api/all-env": {"get": {"summary": "All environment variables", "responses": {"200": {"description": "OK"}}}},
             "/api/headers": {"get": {"summary": "Echo request headers", "responses": {"200": {"description": "OK"}}}},
-            "/api/error": {"get": {"summary": "Return 500", "responses": {"500": {"description": "Server Error"}}}},
+            "/api/error": {"get": {"summary": "Return 503", "responses": {"503": {"description": "Server Error"}}}},
             "/api/error401": {"get": {"summary": "Return 401", "responses": {"401": {"description": "Unauthorized"}}}},
             "/api/error403": {"get": {"summary": "Return 403", "responses": {"403": {"description": "Forbidden"}}}},
-            "/liveness": {"get": {"summary": "Get liveness", "responses": {"200": {"description": "OK"}, "500": {"description": "Not Ready"}}}},
-            "/readiness": {"get": {"summary": "Get readiness", "responses": {"200": {"description": "OK"}, "500": {"description": "Not Ready"}}}},
-            "/started": {"get": {"summary": "Get started", "responses": {"200": {"description": "OK"}, "500": {"description": "Not Started"}}}},
+            "/liveness": {"get": {"summary": "Get liveness", "responses": {"200": {"description": "OK"}, "503": {"description": "Not Ready"}}}},
+            "/readiness": {"get": {"summary": "Get readiness", "responses": {"200": {"description": "OK"}, "503": {"description": "Not Ready"}}}},
+            "/started": {"get": {"summary": "Get started", "responses": {"200": {"description": "OK"}, "503": {"description": "Not Started"}}}},
             "/liveness/{status}": {"post": {"summary": "Set liveness", "parameters": [{"name": "status", "in": "path", "required": True, "schema": {"type": "string"}}], "responses": {"200": {"description": "OK"}, "400": {"description": "Bad Request"}}}},
             "/readiness/{status}": {"post": {"summary": "Set readiness", "parameters": [{"name": "status", "in": "path", "required": True, "schema": {"type": "string"}}], "responses": {"200": {"description": "OK"}, "400": {"description": "Bad Request"}}}},
             "/started/{status}": {"post": {"summary": "Set started", "parameters": [{"name": "status", "in": "path", "required": True, "schema": {"type": "string"}}], "responses": {"200": {"description": "OK"}, "400": {"description": "Bad Request"}}}}
@@ -140,7 +140,7 @@ def api_headers():
 
 @app.route('/api/error')
 def api_error():
-    abort(500)
+    abort(503)
 
 @app.route('/api/error401')
 def api_error401():
@@ -167,7 +167,7 @@ def get_liveness():
     # Per user's mapping: liveness -> is_ready
     if is_ready:
         return ('', 200)
-    return ('', 500)
+    return ('', 503)
 
 
 @app.route('/readiness', methods=['GET'])
@@ -175,14 +175,14 @@ def get_readiness():
     # Per user's mapping: readiness -> is_live
     if is_live:
         return ('', 200)
-    return ('', 500)
+    return ('', 503)
 
 
 @app.route('/started', methods=['GET'])
 def get_started():
     if is_started:
         return ('', 200)
-    return ('', 500)
+    return ('', 503)
 
 
 @app.route('/liveness/<status>', methods=['POST'])

--- a/client.http
+++ b/client.http
@@ -56,5 +56,34 @@ GET http://{{baseUrl}}/api/error401
 
 ###
 
+### Health endpoints (liveness/readiness/started)
+
+### Get liveness (maps to is_ready)
+GET {{baseUrl}}/liveness
+
+### Set liveness to true
+POST {{baseUrl}}/liveness/true
+
+### Set liveness to false
+POST {{baseUrl}}/liveness/false
+
+### Get readiness (maps to is_live)
+GET {{baseUrl}}/readiness
+
+### Set readiness to true
+POST {{baseUrl}}/readiness/true
+
+### Set readiness to false
+POST {{baseUrl}}/readiness/false
+
+### Get started (maps to is_started)
+GET {{baseUrl}}/started
+
+### Set started to true
+POST {{baseUrl}}/started/true
+
+### Set started to false
+POST {{baseUrl}}/started/false
+
 ### /api/error403  (expect 403)
 GET http://{{baseUrl}}/api/error403

--- a/client.http
+++ b/client.http
@@ -1,4 +1,7 @@
 @baseUrl = http://localhost:8080
+### API docs
+# Swagger UI: {{baseUrl}}/docs/
+# OpenAPI JSON: {{baseUrl}}/openapi.json
 ### Root (HTML)
 GET {{baseUrl}}/
 

--- a/html/blue.html
+++ b/html/blue.html
@@ -62,6 +62,8 @@
         <span class="emoji">👋</span>
         <h1>Hello!</h1>
         <p>This is the BLUE Version!!!</p>
+        <br>
+        <a href="/docs">API definition</a>
     </div>
 </body>
 </html>

--- a/html/green.html
+++ b/html/green.html
@@ -62,6 +62,8 @@
         <span class="emoji">👋</span>
         <h1>Hello!</h1>
         <p>This is the GREEN Version!!</p>
+        <br>
+        <a href="/docs">API definition</a>
     </div>
 </body>
 </html>

--- a/html/index.html
+++ b/html/index.html
@@ -62,6 +62,8 @@
         <span class="emoji">👋</span>
         <h1>Hello!</h1>
         <p>Welcome to hello page</p>
+        <br>
+        <a href="/docs">API definition</a>
     </div>
 </body>
 </html>

--- a/html/maintenance.html
+++ b/html/maintenance.html
@@ -56,6 +56,8 @@
         <span class="emoji">🛠️</span>
         <h1>Maintenance</h1>
         <p>We're performing scheduled maintenance.<br>Please check back later!</p>
+        <br>
+        <a href="/docs">API definition</a>
     </div>
 </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Flask==3.0.3
+flask-swagger-ui
+


### PR DESCRIPTION
This pull request adds OpenAPI documentation and a Swagger UI for the API, and introduces health check endpoints for liveness, readiness, and started status. It also updates the error handling for one endpoint and enhances the HTML pages with links to the API definition.

**API Documentation and Health Endpoints**

* Added an `/openapi.json` endpoint that serves a minimal OpenAPI 3.0.2 specification for all public API endpoints, and registered Swagger UI at `/docs` for interactive API exploration.
* Introduced health check endpoints: `/liveness`, `/readiness`, and `/started` (GET to check status, POST to set status), with corresponding boolean flags (`is_ready`, `is_live`, `is_started`) and helper parsing logic. [[1]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R153-R216) [[2]](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L1-R14)
* Updated `client.http` to document and provide example requests for the new health endpoints and API docs. [[1]](diffhunk://#diff-33e215d6773190986ade9c17a21f4aecb64fe39a9c5cec6f8a1d21fa13e6fe7eR2-R4) [[2]](diffhunk://#diff-33e215d6773190986ade9c17a21f4aecb64fe39a9c5cec6f8a1d21fa13e6fe7eR62-R90)

**Error Handling**

* Changed the `/api/error` endpoint to return HTTP 503 (Service Unavailable) instead of 500 (Internal Server Error), to better reflect server health status.

**HTML Page Enhancements**

* Added a link to `/docs` (Swagger UI) on all main HTML pages (`index.html`, `blue.html`, `green.html`, `maintenance.html`) to make the API definition easily accessible. [[1]](diffhunk://#diff-c9f5db8ca708e7a00f0eb981560568a544afb798eaba34269168d6b432454438R65-R66) [[2]](diffhunk://#diff-0445ee86c6d9bd4888be8a7b3e5d25f16457efc78f9d4aecfd01431cf0362922R65-R66) [[3]](diffhunk://#diff-b7e2d20aebd0bfdd5473fb5322e242340a80f145dbca2a93035a82cc3ee15859R65-R66) [[4]](diffhunk://#diff-fcb2e47647566d69b0dc2b1fcecf51bbe9fc6ad571e1156859699754d90c4fc5R59-R60)